### PR TITLE
fix scss deprecation warnings and modernize module system

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,3 +6,4 @@ npx lint-staged
 npx lint-staged
 npx lint-staged
 npx lint-staged
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "redux": "^5.0.1",
         "redux-logger": "^3.0.6",
         "redux-persist": "^6.0.0",
-        "sass": "^1.69.5",
         "styled-components": "^6.1.13",
         "tesseract.js": "^5.1.1",
         "yup": "^1.3.3"
@@ -85,6 +84,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^15.2.0",
         "prettier": "^3.1.1",
+        "sass": "^1.81.0",
         "vite": "^5.4.11"
     },
     "lint-staged": {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,4 @@
-@import './constants/colors.scss';
-@import './constants/typography.scss';
+@use '@constants' as *;
 
 :root {
     font-family: $font-primary;

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .card-small {
     height: 117px;

--- a/src/components/ClaimSteps/CreateClaimStep/CreateClaimStep.scss
+++ b/src/components/ClaimSteps/CreateClaimStep/CreateClaimStep.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .claim-steps {
     h4 {

--- a/src/components/ClaimSteps/Pictures/Pictures.scss
+++ b/src/components/ClaimSteps/Pictures/Pictures.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .picture-step {
     display: flex;

--- a/src/components/ClaimsHeader/ClaimsHeader.scss
+++ b/src/components/ClaimsHeader/ClaimsHeader.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .claim-header {
     h4 {

--- a/src/components/ClaimsTab/ClaimsTab.scss
+++ b/src/components/ClaimsTab/ClaimsTab.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .data-table-custom {
     background-color: transparent;

--- a/src/components/Dashboard/DropDown/Notification/notifcationdropdown.scss
+++ b/src/components/Dashboard/DropDown/Notification/notifcationdropdown.scss
@@ -1,6 +1,6 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
-@import '@constants/bootstrap-overrides.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
+@use '@constants/bootstrap-overrides.scss';
 
 .notification-dropdown {
     button {

--- a/src/components/Dashboard/DropDown/Profile/profiledropdown.scss
+++ b/src/components/Dashboard/DropDown/Profile/profiledropdown.scss
@@ -1,5 +1,5 @@
-@import '../../../constants/colors.scss';
-@import '../../../constants/typography.scss';
+@use '../../../constants/colors.scss';
+@use '../../../constants/typography.scss';
 
 .sidebar {
     position: fixed;

--- a/src/components/Dashboard/MainPanel/mainpanel.scss
+++ b/src/components/Dashboard/MainPanel/mainpanel.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .main-panel {
     position: relative;

--- a/src/components/Dashboard/Sidebar/sidebar.scss
+++ b/src/components/Dashboard/Sidebar/sidebar.scss
@@ -1,5 +1,5 @@
-@import '../../../constants/colors.scss';
-@import '../../../constants/typography.scss';
+@use '@constants' as *;
+
 .sidebar {
     position: fixed;
     top: 0;

--- a/src/components/Dashboard/Topbar/topbar.scss
+++ b/src/components/Dashboard/Topbar/topbar.scss
@@ -1,5 +1,4 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants' as *;
 
 .top-nav {
     width: 100%;

--- a/src/components/Home/StatCard/statcard.scss
+++ b/src/components/Home/StatCard/statcard.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 .stat-card {
     display: flex;
     flex-direction: row;

--- a/src/components/Input/input.scss
+++ b/src/components/Input/input.scss
@@ -1,6 +1,4 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
-@import '@constants/media.scss';
+@use '@constants' as *;
 
 .form-inline {
     label {

--- a/src/components/Modal/ArchiveModal/ArchiveModal.scss
+++ b/src/components/Modal/ArchiveModal/ArchiveModal.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .archive-modal {
     backdrop-filter: blur(10px);

--- a/src/components/Modal/DeleteModal/DeleteModal.scss
+++ b/src/components/Modal/DeleteModal/DeleteModal.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .delete-modal {
     h4 {

--- a/src/components/Modal/DownloadClaimForm/DownloadClaimForm.scss
+++ b/src/components/Modal/DownloadClaimForm/DownloadClaimForm.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .download-pdf {
     h4 {

--- a/src/components/Modal/EditClaimModal/EditClaimModal.scss
+++ b/src/components/Modal/EditClaimModal/EditClaimModal.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .download-pdf {
     h4 {

--- a/src/components/Modal/LogoutModal/LogoutModal.scss
+++ b/src/components/Modal/LogoutModal/LogoutModal.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .logout-modal {
     backdrop-filter: blur(10px);

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -1,6 +1,6 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
-@import '@constants/media.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
+@use '@constants/media.scss';
 
 .modal-title {
     font-size: $text-color;

--- a/src/components/Modal/RetakePictureModal/RetakePictureModal.scss
+++ b/src/components/Modal/RetakePictureModal/RetakePictureModal.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .retake-modal {
     backdrop-filter: blur(10px);
@@ -22,7 +22,7 @@
                 rgba(242, 92, 34, 1)
             );
             display: flex;
-            justify-content: center;@import '@constants/colors.scss';
+            justify-content: center;@use '@constants/colors.scss';
 
             .retake-modal {
                 backdrop-filter: blur(10px);

--- a/src/components/StepperChilds/OdometerStep/OdometerReview/OdometerStep.scss
+++ b/src/components/StepperChilds/OdometerStep/OdometerReview/OdometerStep.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants' as *;
 
 .stepper-main-form {
     display: flex;

--- a/src/components/StepperChilds/StepperMain.scss
+++ b/src/components/StepperChilds/StepperMain.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants' as *;
 
 .stepper-main {
     display: flex;

--- a/src/components/StepperChilds/VinStep/VinQualityCheck/VinQualityCheck.scss
+++ b/src/components/StepperChilds/VinStep/VinQualityCheck/VinQualityCheck.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .vin-quality-check {
     display: flex;

--- a/src/components/ViewClaimHeader/ViewClaimHeader.scss
+++ b/src/components/ViewClaimHeader/ViewClaimHeader.scss
@@ -1,5 +1,5 @@
-@import '../../constants/colors.scss';
-@import '@constants/typography.scss';
+@use '../../constants/colors.scss';
+@use '@constants/typography.scss';
 
 .view-claim-header {
     box-shadow: 0px 33px 33px 0px #dadcfa;

--- a/src/constants/colors.scss
+++ b/src/constants/colors.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Color Palette
 $primary-color: #ff5f1e;                     // Primary color
 $primary-btn: linear-gradient(to right, #ffbb00, #ff8c00); // Action Gradient
@@ -16,7 +18,7 @@ $primary-border: #ffd900;                    // Secondary Gradient
 $text-color: #171717;                        // Dark color for inner text
 $heading-color: #171717;                     // Dark color for headings
 $link-color: $primary-color;                 // Link color
-$link-hover-color: adjust-color($link-color, $lightness: -10%); // Link hover color
+$link-hover-color: color.adjust($link-color, $lightness: -10%); // Link hover color
 
 // Background Colors
 $body-bg-color: #fffdf9;                     // Body background (Off-white)
@@ -81,5 +83,5 @@ $primary-color: #f25c22;                     // Primary brand color
 $secondary-color: #0fcba8;                   // Secondary brand color
 
 // Color Adjustments for Buttons
-$primary-btn-light: adjust-color($primary-color, $lightness: 10%); // Light variant of the primary color
-$primary-btn-dark: adjust-color($primary-color, $lightness: -10%);  // Dark variant of the primary color
+$primary-btn-light: color.adjust($primary-color, $lightness: 10%); // Light variant of the primary color
+$primary-btn-dark: color.adjust($primary-color, $lightness: -10%);  // Dark variant of the primary color

--- a/src/constants/index.scss
+++ b/src/constants/index.scss
@@ -1,0 +1,5 @@
+@forward '@constants/colors';
+@forward '@constants/typography';
+@forward '@constants/media';
+@forward '@constants/bootstrap-overrides';
+@forward '@constants/chart-customs';

--- a/src/pages/Auth/auth.scss
+++ b/src/pages/Auth/auth.scss
@@ -1,6 +1,4 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
-@import '@constants/media.scss';
+@use '@constants' as *;
 
 .auth-main-wrapper {
     display: flex;

--- a/src/pages/ClaimSubmitted/ClaimSubmitted.scss
+++ b/src/pages/ClaimSubmitted/ClaimSubmitted.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants' as *;
 
 .claim-submit {
     display: flex;

--- a/src/pages/Claims/Claims.scss
+++ b/src/pages/Claims/Claims.scss
@@ -1,5 +1,5 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
+@use '@constants/colors.scss';
+@use '@constants/typography.scss';
 
 .claims {
     // Styling for active tab

--- a/src/pages/ContactUs/ContactUs.scss
+++ b/src/pages/ContactUs/ContactUs.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .contact-us {
     padding: 20px;

--- a/src/pages/ContactUsAdmin/ContactUsAdmin.scss
+++ b/src/pages/ContactUsAdmin/ContactUsAdmin.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 .contact-us {
     display: flex;
     flex-direction: column;

--- a/src/pages/CreateClaim/CreateClaim.scss
+++ b/src/pages/CreateClaim/CreateClaim.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .step-component {
     display: flex;

--- a/src/pages/HowItWorks/HowItWorks.scss
+++ b/src/pages/HowItWorks/HowItWorks.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants' as *;
 
 .how-it-works {
     display: flex;

--- a/src/pages/LandingPage/landingPage.scss
+++ b/src/pages/LandingPage/landingPage.scss
@@ -1,4 +1,4 @@
-@import '@constants/typography.scss';
+@use '@constants' as *;
 
 .landing {
     background-image: url('@images/car_dashboard.jpg');

--- a/src/pages/Listing/Listing.scss
+++ b/src/pages/Listing/Listing.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .listing-page {
     .action-button {

--- a/src/pages/QualityCheck/QualityCheck.scss
+++ b/src/pages/QualityCheck/QualityCheck.scss
@@ -1,6 +1,4 @@
-@import '@constants/colors.scss';
-@import '@constants/typography.scss';
-@import '@constants/media.scss';
+@use '@constants' as *;
 
 .quality-check {
     display: flex;

--- a/src/pages/ViewClaims/ViewClaims.scss
+++ b/src/pages/ViewClaims/ViewClaims.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants/colors.scss';
 
 .view-content {
     display: flex;

--- a/src/pages/WelcomeScreen/WelcomeScreen.scss
+++ b/src/pages/WelcomeScreen/WelcomeScreen.scss
@@ -1,4 +1,4 @@
-@import '@constants/colors.scss';
+@use '@constants' as *;
 
 .welcome-screen {
     display: flex;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
+import sass from 'sass';
 
 export default defineConfig({
     resolve: {
@@ -14,7 +15,15 @@ export default defineConfig({
             '@logos': path.resolve('./src/assets/logos'),
             '@pages': path.resolve('./src/pages'),
             '@layout': path.resolve('./src/layout'),
-            '@redux': path.resolve('./src/redux'),
+            '@redux': path.resolve('./src/redux')
+        }
+    },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                implementation: sass,
+                api: 'modern'
+            }
         }
     },
     plugins: [
@@ -26,11 +35,11 @@ export default defineConfig({
         outDir: 'dist',
         sourcemap: false,
         minify: true,
-        assetsDir: 'assets',
+        assetsDir: 'assets'
     },
     server: {
         host: '0.0.0.0', // Allow access from your network
-        port: 3000,      // You can adjust this if needed
-        open: true       // Opens the app in a local browser by default
+        port: 3000, // You can adjust this if needed
+        open: true // Opens the app in a local browser by default
     }
 });


### PR DESCRIPTION
Started with a SASS deprecation warning about legacy JS API, discovered undefined variables in SCSS files, and found missing mixins. Fixed these by modernizing the SCSS architecture to use Sass modules, updated Vite config to use modern API, and centralized constants to reduce verbose imports that were causing developer friction.
